### PR TITLE
Make mathoid options configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ debian/mathoid.prerm.debhelper
 debian/mathoid.substvars
 node_modules
 .idea
-mathoid.iml
+mathoid*.iml

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -33,3 +33,7 @@ services:
       port: 10042
       # interface: localhost # uncomment to only listen on localhost
       # more per-service config settings
+      svg: true
+      img: true
+      png: true #new feature
+      speakText: true #new feature

--- a/config.prod.yaml
+++ b/config.prod.yaml
@@ -33,3 +33,5 @@ services:
       port: 10042
       # interface: localhost # uncomment to only listen on localhost
       # more per-service config settings
+      svg: true
+      img: true

--- a/config.yaml
+++ b/config.yaml
@@ -33,3 +33,7 @@ services:
       port: 10042
       # interface: localhost # uncomment to only listen on localhost
       # more per-service config settings
+      svg: true
+      img: true
+      png: true #new feature
+      speakText: true #new feature

--- a/routes/root.js
+++ b/routes/root.js
@@ -56,7 +56,14 @@ function handleRequest(res, q, type) {
     if (type === "ascii" || type === "asciimath") {
         type = "AsciiMath";
     }
-    app.mjAPI.typeset({math: q, format: type, svg: true, img: true, mml: mml, speakText: true, png: true}, function (data) {
+    app.mjAPI.typeset( {
+        math: q,
+        format: type,
+        svg: app.conf.svg,
+        img: app.conf.img,
+        mml: mml,
+        speakText: app.conf.speakText,
+        png: app.conf.png }, function (data) {
         if (data.errors) {
             data.success = false;
             data.log = "Error:" + JSON.stringify(data.errors);


### PR DESCRIPTION
Use default rest-service-template way to pass configuration
to mathoid.

Change-Id: Ia7a8b3062493a071460994157f405796d076f5fa